### PR TITLE
fix: adjust CI workflow to use npm install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,9 +16,8 @@ jobs:  # Job definitions
         uses: actions/setup-node@v4  # Official setup action
         with:  # Action inputs
           node-version: 18  # Use Node.js v18
-          cache: npm  # Cache npm modules
       - name: Install dependencies  # Install packages
-        run: npm ci  # Clean install
+        run: npm install  # Install packages
       - name: Build project  # Compile assets
         run: npm run build  # Webpack build
       - name: Run tests  # Execute tests
@@ -36,7 +35,7 @@ jobs:  # Job definitions
         with:  # Action inputs
           node-version: 18  # Use Node.js v18
       - name: Install dependencies  # Install packages
-        run: npm ci  # Clean install
+        run: npm install  # Install packages
       - name: Deploy to Vercel  # Deployment step
         uses: amondnet/vercel-action@v20  # Vercel action
         with:  # Action inputs

--- a/task-fix-ci.md
+++ b/task-fix-ci.md
@@ -1,0 +1,48 @@
+# Context
+Filename: task-fix-ci.md
+Created: 2025-08-21 03:44
+Author: chatgpt
+Protocol: RIPER-5 + Multi-Dim + Agent + AI-Dev Guide
+
+# Task Description
+Resolve GitHub Actions workflow failure caused by missing dependency lock file.
+
+# Project Overview
+3D portfolio website built with Three.js and an embedded OS displayed via iframe.
+
+---
+# Analysis (Research)
+The workflow uses `cache: npm` and `npm ci`, both of which require a lock file. Repository lacks any lock file.
+
+# Proposed Solutions (Innovation)
+## Plan A:
+- Principle: Remove cache usage and switch to `npm install`.
+- Steps: Delete cache option; replace `npm ci` with `npm install`.
+- Risks: Slightly slower dependency installation.
+
+## Plan B:
+- Principle: Commit a lock file to satisfy `npm ci` and cache.
+- Steps: Generate `package-lock.json`; keep workflow as-is.
+- Risks: Large diff; maintenance of lock file.
+
+## Recommended Plan
+Plan A is preferred for minimal changes and immediate fix.
+
+# Implementation Plan (Planning)
+Implementation Checklist:
+1. Edit `.github/workflows/ci.yml` to remove caching and use `npm install`.
+
+# Current Step
+Executing: "1. Edit workflow"
+
+# Task Progress
+* 2025-08-21 03:45
+  * Step: Edit workflow
+  * Changes: Removed `cache: npm` and replaced `npm ci` with `npm install` in both jobs.
+  * Summary: Workflow no longer depends on lock file.
+  * Reason: Prevent failure when lock file absent.
+  * Blockers: None
+  * Status: completed
+
+# Final Review
+Workflow updated to install dependencies without requiring a lock file.


### PR DESCRIPTION
## Summary
- avoid dependency lockfile requirement by switching to `npm install`
- add task file documenting the CI fix

## Testing
- `npm install`
- `npm run build`
- `npm test --if-present`


------
https://chatgpt.com/codex/tasks/task_e_68a6956ca8008333a61c0260aa293a9b